### PR TITLE
remove parallel iterators

### DIFF
--- a/src/multilinear_pc/mod.rs
+++ b/src/multilinear_pc/mod.rs
@@ -141,7 +141,7 @@ impl<E: PairingEngine> MultilinearPC<E> {
         let nv = polynomial.num_vars();
         let scalars: Vec<_> = polynomial
             .to_evaluations()
-            .into_par_iter()
+            .into_iter()
             .map(|x| x.into_repr())
             .collect();
         let g_product =
@@ -172,21 +172,15 @@ impl<E: PairingEngine> MultilinearPC<E> {
         for mut p in proofs {
             let k = nv - i;
             let point_at_k = point[i];
-            q[k] = (0..(1 << (k - 1)))
-                .into_par_iter()
-                .map(|_| E::Fr::zero())
-                .collect();
-            r[k - 1] = (0..(1 << (k - 1)))
-                .into_par_iter()
-                .map(|_| E::Fr::zero())
-                .collect();
+            q[k] = (0..(1 << (k - 1))).map(|_| E::Fr::zero()).collect();
+            r[k - 1] = (0..(1 << (k - 1))).map(|_| E::Fr::zero()).collect();
             for b in 0..(1 << (k - 1)) {
                 q[k][b] = r[k][(b << 1) + 1] - &r[k][b << 1];
                 r[k - 1][b] = r[k][b << 1] * &(E::Fr::one() - &point_at_k)
                     + &(r[k][(b << 1) + 1] * &point_at_k);
             }
             let scalars: Vec<_> = (0..(1 << k))
-                .into_par_iter()
+                .into_iter()
                 .map(|x| q[k][x >> 1].into_repr()) // fine
                 .collect();
             let ph = ck.powers_of_h[i].clone();
@@ -204,13 +198,13 @@ impl<E: PairingEngine> MultilinearPC<E> {
         }
 
         let proofs = thread_handles
-            .into_par_iter()
+            .into_iter()
             .map(|h| h.join().unwrap())
             .collect();
 
         // let res = s
-        //     .into_par_iter()
-        //     .zip(ck.powers_of_h.clone().into_par_iter())
+        //
+        //     .zip(ck.powers_of_h.clo)
         //     .map(|(si, hi)| VariableBaseMSM::multi_scalar_mul(&hi, &si).into_affine())
         //     .collect::<Vec<_>>();
         // print!("{:?}", res);
@@ -241,25 +235,25 @@ impl<E: PairingEngine> MultilinearPC<E> {
             FixedBaseMSM::multi_scalar_mul(scalar_size, window_size, &g_table, point);
 
         let pairing_lefts: Vec<_> = (0..vk.nv)
-            .into_par_iter()
+            .into_iter()
             .map(|i| vk.g_mask_random[i].into_projective() - &g_mul[i])
             .collect();
         let pairing_lefts: Vec<E::G1Affine> =
             E::G1Projective::batch_normalization_into_affine(&pairing_lefts);
         let pairing_lefts: Vec<E::G1Prepared> = pairing_lefts
-            .into_par_iter()
+            .into_iter()
             .map(|x| E::G1Prepared::from(x))
             .collect();
 
         let pairing_rights: Vec<E::G2Prepared> = proof
             .proofs
-            .par_iter()
+            .iter()
             .map(|x| E::G2Prepared::from(*x))
             .collect();
 
         let pairings: Vec<_> = pairing_lefts
-            .into_par_iter()
-            .zip(pairing_rights.into_par_iter())
+            .into_iter()
+            .zip(pairing_rights.into_iter())
             .collect();
         let right = E::product_of_pairings(pairings.iter());
         // println!("right is {:?}", right);
@@ -365,7 +359,7 @@ mod tests {
     #[test]
     fn setup_commit_verify_incorrect_polynomial_should_return_false() {
         let mut rng = test_rng();
-        let nv = 8;
+        let nv = 2;
         let uni_params = MultilinearPC::setup(nv, &mut rng);
         let poly = DenseMultilinearExtension::rand(nv, &mut rng);
         let nv = uni_params.num_vars;


### PR DESCRIPTION
Removed parallelisation from everywhere but  the `open` function as it doesn't help performance.